### PR TITLE
修复：使用 musl 构建静态链接的 Linux 二进制文件

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           # Linux x64
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            use_cross: false
+            use_cross: true
             archive_ext: .tar.gz
             artifact_name: linux-x64
           # macOS x64


### PR DESCRIPTION
使用 musl target 构建一个完全静态链接的 Linux 二进制文件。
这可以避免在不同的 Linux 发行版上运行时出现 glibc 兼容性问题。

修复 #1